### PR TITLE
allow empyt value for numeric inputs

### DIFF
--- a/CTDopts/CTDopts.py
+++ b/CTDopts/CTDopts.py
@@ -440,6 +440,8 @@ class Parameter(object):
                 else:
                     defaults_to_validate.append(default)
                 for default_to_validate in defaults_to_validate:
+                    if default_to_validate == '':
+                        continue
                     try:
                         if self.type is int:
                             int(default_to_validate)


### PR DESCRIPTION
The CTDConverter fails for `value=""` for numeric mandatory inputs:

```
  File "CTDConverter/convert.py", line 215, in main
    converter.get_preferred_file_extension())
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDConverter/common/utils.py", line 118, in parse_input_ctds
    parsed_ctds.append(ParsedCTD(CTDModel(from_file=input_ctd), input_ctd, output_file))
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 643, in __init__
    self._load_from_file(from_file)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 688, in _load_from_file
    self.parameters = self._build_param_model(params_container_node, base=None)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 708, in _build_param_model
    self._build_param_model(child, current_group)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 708, in _build_param_model
    self._build_param_model(child, current_group)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 713, in _build_param_model
    base.add(**setup)  # register parameter in model
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 564, in add
    self.parameters[name] = Parameter(name, self, **kwargs)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 376, in __init__
    self._validate_numerical_defaults(default)
  File "/home/berntm/projects/tools-galaxyp/tools/openms/gen-test/CTDopts/CTDopts/CTDopts.py", line 456, in _validate_numerical_defaults
    "default": ', '.join(map(str, errors_so_far))})
ModelParsingError: An error occurred while parsing the CTD file: Invalid default value(s) provided for parameter param_wodefault_mandatory_unrestricted of type <type 'float'>: ''
ERROR: There seems to be a problem with one of your input CTDs.
```

Not sure if there is a better way to do it (e.g. alternatively `""` could be removed from the list)